### PR TITLE
Build different versions of each image

### DIFF
--- a/.github/workflows/almalinux.yml
+++ b/.github/workflows/almalinux.yml
@@ -1,0 +1,156 @@
+name: Build AlmaLinux images
+
+on:
+  schedule:
+    - cron: '20 20 * * *'  # 8:20pm everyday
+  pull_request:
+    branches:
+      - main
+    paths:
+      - almalinux/**
+      - .github/workflows/almalinux.yml
+  push:
+    branches:
+      - main
+    paths:
+      - almalinux/**
+      - .github/workflows/almalinux.yml
+  workflow_dispatch:
+
+env:
+  DISTRO: 'almalinux'
+  IMAGE_NAME: 'toolbx-almalinux'
+  REGISTRY_URL: ghcr.io
+  REGISTRY_USERNAME: ${{ github.repository_owner }}
+  REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        major_version: [9]
+        include:
+          - major_version: 9
+            is_latest: true
+
+    steps:
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log into registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY_URL }}
+          username: ${{ env.REGISTRY_USERNAME }}
+          password: ${{ env.REGISTRY_PASSWORD }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.REGISTRY_URL }}/${{ env.REGISTRY_USERNAME }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            type=semver,pattern={{version}}
+            type=sha,prefix=sha256-
+
+      - name: Extract Docker PR tag
+        if: github.event_name == 'pull_request'
+        id: meta_pr
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.REGISTRY_URL }}/${{ env.REGISTRY_USERNAME }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            type=ref,suffix=-${{ matrix.major_version }},event=pr
+
+      - name: Extract Docker date tag
+        if: github.event_name == 'schedule'
+        id: meta_date
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.REGISTRY_URL }}/${{ env.REGISTRY_USERNAME }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            type=schedule,prefix=${{ matrix.major_version }}-,pattern={{date 'YYYYMMDD'}}
+
+      - name: Extract Docker major version tag
+        if: |
+          github.event_name != 'pull_request' && matrix.major_version != ''
+        id: meta_version
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.REGISTRY_URL }}/${{ env.REGISTRY_USERNAME }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            type=raw,value=${{ matrix.major_version }}
+
+      - name: Extract Docker latest tag
+        if: |
+          github.event_name != 'pull_request' && matrix.is_latest == true
+        id: meta_latest
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.REGISTRY_URL }}/${{ env.REGISTRY_USERNAME }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            type=raw,value=latest
+
+      - name: Build Image
+        id: build_image
+        uses: redhat-actions/buildah-build@v2
+        with:
+          context: |
+            ./${{ env.DISTRO }}
+          containerfiles: |
+            ./${{ env.DISTRO }}/Containerfile
+          tags: |
+            ${{ steps.meta.outputs.tags }}
+            ${{ steps.meta_pr.outputs.tags }}
+            ${{ steps.meta_date.outputs.tags }}
+            ${{ steps.meta_version.outputs.tags }}
+            ${{ steps.meta_latest.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            MAJOR_VERSION=${{ matrix.major_version }}
+          oci: false
+
+      - name: Push to container registries
+        uses: redhat-actions/push-to-registry@v2
+        id: push
+        with:
+          tags: ${{ steps.build_image.outputs.tags }}
+          extra-args: |
+            --disable-content-trust
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3.1.2
+
+      - name: Sign container image
+        run: |
+          cosign sign -y --key env://COSIGN_PRIVATE_KEY ${{ env.REGISTRY_URL }}/${{ env.REGISTRY_USERNAME }}/${{ env.IMAGE_NAME }}@${TAGS}
+        env:
+          TAGS: ${{ steps.push.outputs.digest }}
+          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_KEY }}
+          COSIGN_EXPERIMENTAL: false
+
+      - name: Echo outputs
+        run: |
+          echo "${{ toJSON(steps.push.outputs) }}"

--- a/.github/workflows/alpine.yml
+++ b/.github/workflows/alpine.yml
@@ -1,0 +1,158 @@
+name: Build Alpine images
+
+on:
+  schedule:
+    - cron: '20 20 * * *'  # 8:20pm everyday
+  pull_request:
+    branches:
+      - main
+    paths:
+      - alpine/**
+      - .github/workflows/alpine.yml
+  push:
+    branches:
+      - main
+    paths:
+      - alpine/**
+      - .github/workflows/alpine.yml
+  workflow_dispatch:
+
+env:
+  DISTRO: 'alpine'
+  IMAGE_NAME: 'toolbx-alpine'
+  REGISTRY_URL: ghcr.io
+  REGISTRY_USERNAME: ${{ github.repository_owner }}
+  REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        major_version: ['latest', 'edge']
+        include:
+          - major_version: 'latest'
+            is_latest: true
+          - major_version: 'edge'
+            is_latest: false
+
+    steps:
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log into registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY_URL }}
+          username: ${{ env.REGISTRY_USERNAME }}
+          password: ${{ env.REGISTRY_PASSWORD }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.REGISTRY_URL }}/${{ env.REGISTRY_USERNAME }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            type=semver,pattern={{version}}
+            type=sha,prefix=sha256-
+
+      - name: Extract Docker PR tag
+        if: github.event_name == 'pull_request'
+        id: meta_pr
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.REGISTRY_URL }}/${{ env.REGISTRY_USERNAME }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            type=ref,suffix=-${{ matrix.major_version }},event=pr
+
+      - name: Extract Docker date tag
+        if: github.event_name == 'schedule'
+        id: meta_date
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.REGISTRY_URL }}/${{ env.REGISTRY_USERNAME }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            type=schedule,prefix=${{ matrix.major_version }}-,pattern={{date 'YYYYMMDD'}}
+
+      - name: Extract Docker major version tag
+        if: |
+          github.event_name != 'pull_request' && matrix.major_version != ''
+        id: meta_version
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.REGISTRY_URL }}/${{ env.REGISTRY_USERNAME }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            type=raw,value=${{ matrix.major_version }}
+
+      - name: Extract Docker latest tag
+        if: |
+          github.event_name != 'pull_request' && matrix.is_latest == true
+        id: meta_latest
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.REGISTRY_URL }}/${{ env.REGISTRY_USERNAME }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            type=raw,value=latest
+
+      - name: Build Image
+        id: build_image
+        uses: redhat-actions/buildah-build@v2
+        with:
+          context: |
+            ./${{ env.DISTRO }}
+          containerfiles: |
+            ./${{ env.DISTRO }}/Containerfile
+          tags: |
+            ${{ steps.meta.outputs.tags }}
+            ${{ steps.meta_pr.outputs.tags }}
+            ${{ steps.meta_date.outputs.tags }}
+            ${{ steps.meta_version.outputs.tags }}
+            ${{ steps.meta_latest.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            MAJOR_VERSION=${{ matrix.major_version }}
+          oci: false
+
+      - name: Push to container registries
+        uses: redhat-actions/push-to-registry@v2
+        id: push
+        with:
+          tags: ${{ steps.build_image.outputs.tags }}
+          extra-args: |
+            --disable-content-trust
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3.1.2
+
+      - name: Sign container image
+        run: |
+          cosign sign -y --key env://COSIGN_PRIVATE_KEY ${{ env.REGISTRY_URL }}/${{ env.REGISTRY_USERNAME }}/${{ env.IMAGE_NAME }}@${TAGS}
+        env:
+          TAGS: ${{ steps.push.outputs.digest }}
+          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_KEY }}
+          COSIGN_EXPERIMENTAL: false
+
+      - name: Echo outputs
+        run: |
+          echo "${{ toJSON(steps.push.outputs) }}"

--- a/.github/workflows/archlinux.yml
+++ b/.github/workflows/archlinux.yml
@@ -1,0 +1,156 @@
+name: Build ArchLinux images
+
+on:
+  schedule:
+    - cron: '20 20 * * *'  # 8:20pm everyday
+  pull_request:
+    branches:
+      - main
+    paths:
+      - archlinux/**
+      - .github/workflows/archlinux.yml
+  push:
+    branches:
+      - main
+    paths:
+      - archlinux/**
+      - .github/workflows/archlinux.yml
+  workflow_dispatch:
+
+env:
+  DISTRO: 'archlinux'
+  IMAGE_NAME: 'toolbx-archlinux'
+  REGISTRY_URL: ghcr.io
+  REGISTRY_USERNAME: ${{ github.repository_owner }}
+  REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        major_version: ['latest']
+        include:
+          - major_version: 'latest'
+            is_latest: true
+
+    steps:
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log into registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY_URL }}
+          username: ${{ env.REGISTRY_USERNAME }}
+          password: ${{ env.REGISTRY_PASSWORD }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.REGISTRY_URL }}/${{ env.REGISTRY_USERNAME }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            type=semver,pattern={{version}}
+            type=sha,prefix=sha256-
+
+      - name: Extract Docker PR tag
+        if: github.event_name == 'pull_request'
+        id: meta_pr
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.REGISTRY_URL }}/${{ env.REGISTRY_USERNAME }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            type=ref,suffix=-${{ matrix.major_version }},event=pr
+
+      - name: Extract Docker date tag
+        if: github.event_name == 'schedule'
+        id: meta_date
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.REGISTRY_URL }}/${{ env.REGISTRY_USERNAME }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            type=schedule,prefix=${{ matrix.major_version }}-,pattern={{date 'YYYYMMDD'}}
+
+      - name: Extract Docker major version tag
+        if: |
+          github.event_name != 'pull_request' && matrix.major_version != ''
+        id: meta_version
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.REGISTRY_URL }}/${{ env.REGISTRY_USERNAME }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            type=raw,value=${{ matrix.major_version }}
+
+      - name: Extract Docker latest tag
+        if: |
+          github.event_name != 'pull_request' && matrix.is_latest == true
+        id: meta_latest
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.REGISTRY_URL }}/${{ env.REGISTRY_USERNAME }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            type=raw,value=latest
+
+      - name: Build Image
+        id: build_image
+        uses: redhat-actions/buildah-build@v2
+        with:
+          context: |
+            ./${{ env.DISTRO }}
+          containerfiles: |
+            ./${{ env.DISTRO }}/Containerfile
+          tags: |
+            ${{ steps.meta.outputs.tags }}
+            ${{ steps.meta_pr.outputs.tags }}
+            ${{ steps.meta_date.outputs.tags }}
+            ${{ steps.meta_version.outputs.tags }}
+            ${{ steps.meta_latest.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            MAJOR_VERSION=${{ matrix.major_version }}
+          oci: false
+
+      - name: Push to container registries
+        uses: redhat-actions/push-to-registry@v2
+        id: push
+        with:
+          tags: ${{ steps.build_image.outputs.tags }}
+          extra-args: |
+            --disable-content-trust
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3.1.2
+
+      - name: Sign container image
+        run: |
+          cosign sign -y --key env://COSIGN_PRIVATE_KEY ${{ env.REGISTRY_URL }}/${{ env.REGISTRY_USERNAME }}/${{ env.IMAGE_NAME }}@${TAGS}
+        env:
+          TAGS: ${{ steps.push.outputs.digest }}
+          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_KEY }}
+          COSIGN_EXPERIMENTAL: false
+
+      - name: Echo outputs
+        run: |
+          echo "${{ toJSON(steps.push.outputs) }}"

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -1,4 +1,4 @@
-name: Build image
+name: Build Debian images
 
 on:
   schedule:
@@ -6,21 +6,20 @@ on:
   pull_request:
     branches:
       - main
-    paths-ignore:
-      - 'README*'
-      - '*.md'
-      - '*.txt'
+    paths:
+      - debian/**
+      - .github/workflows/debian.yml
   push:
     branches:
       - main
-    paths-ignore:
-      - 'README*'
-      - '*.md'
-      - '*.txt'
+    paths:
+      - debian/**
+      - .github/workflows/debian.yml
   workflow_dispatch:
 
 env:
-  IMAGE_NAME: ${{ github.event.repository.name }}
+  DISTRO: 'debian'
+  IMAGE_NAME: 'toolbx-debian'
   REGISTRY_URL: ghcr.io
   REGISTRY_USERNAME: ${{ github.repository_owner }}
   REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
@@ -35,34 +34,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distro:
-          - 'fedora'
-          - 'almalinux'
-          - 'alpine'
-          - 'archlinux'
-          - 'debian'
-          - 'opensuse'
-          - 'rhel'
-          - 'rockylinux'
-          - 'ubuntu'
+        major_version: [12, 'unstable']
         include:
-          - distro: 'fedora'
+          - major_version: 12
             is_latest: true
-          - distro: 'almalinux'
-            is_latest: false
-          - distro: 'alpine'
-            is_latest: false
-          - distro: 'archlinux'
-            is_latest: false
-          - distro: 'debian'
-            is_latest: false
-          - distro: 'opensuse'
-            is_latest: false
-          - distro: 'rhel'
-            is_latest: false
-          - distro: 'rockylinux'
-            is_latest: false
-          - distro: 'ubuntu'
+          - major_version: 'unstable'
             is_latest: false
 
     steps:
@@ -78,8 +54,6 @@ jobs:
           password: ${{ env.REGISTRY_PASSWORD }}
 
       - name: Extract Docker metadata
-        if: |
-          github.event_name != 'pull_request'
         id: meta
         uses: docker/metadata-action@v5
         with:
@@ -87,10 +61,48 @@ jobs:
             ${{ env.REGISTRY_URL }}/${{ env.REGISTRY_USERNAME }}/${{ env.IMAGE_NAME }}
           flavor: |
             latest=false
-          labels: |
-            io.artifacthub.package.readme-url=https://raw.githubusercontent.com/${{ github.repository }}/main/README.md
+          tags: |
+            type=semver,pattern={{version}}
+            type=sha,prefix=sha256-
 
-      - name: Extract Docker latest metadata
+      - name: Extract Docker PR tag
+        if: github.event_name == 'pull_request'
+        id: meta_pr
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.REGISTRY_URL }}/${{ env.REGISTRY_USERNAME }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            type=ref,suffix=-${{ matrix.major_version }},event=pr
+
+      - name: Extract Docker date tag
+        if: github.event_name == 'schedule'
+        id: meta_date
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.REGISTRY_URL }}/${{ env.REGISTRY_USERNAME }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            type=schedule,prefix=${{ matrix.major_version }}-,pattern={{date 'YYYYMMDD'}}
+
+      - name: Extract Docker major version tag
+        if: |
+          github.event_name != 'pull_request' && matrix.major_version != ''
+        id: meta_version
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.REGISTRY_URL }}/${{ env.REGISTRY_USERNAME }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            type=raw,value=${{ matrix.major_version }}
+
+      - name: Extract Docker latest tag
         if: |
           github.event_name != 'pull_request' && matrix.is_latest == true
         id: meta_latest
@@ -103,58 +115,23 @@ jobs:
           tags: |
             type=raw,value=latest
 
-      - name: Extract Docker distro metadata
-        if: |
-          github.event_name != 'pull_request' && matrix.distro != ''
-        id: meta_distro
-        uses: docker/metadata-action@v5
-        with:
-          images: |
-            ${{ env.REGISTRY_URL }}/${{ env.REGISTRY_USERNAME }}/${{ env.IMAGE_NAME }}
-          flavor: |
-            latest=false
-          tags: |
-            type=raw,value=${{ matrix.distro }}
-
-      - name: Extract Docker PR metadata
-        if: |
-          github.event_name == 'pull_request' && matrix.distro != ''
-        id: meta_pr
-        uses: docker/metadata-action@v5
-        with:
-          images: |
-            ${{ env.REGISTRY_URL }}/${{ env.REGISTRY_USERNAME }}/${{ env.IMAGE_NAME }}
-          flavor: |
-            latest=false
-          tags: |
-            type=ref,suffix=-${{ matrix.distro }},event=pr
-
-      - name: Extract Docker date tag
-        if: |
-          github.event_name == 'schedule' && matrix.distro != ''
-        id: meta_date
-        uses: docker/metadata-action@v5
-        with:
-          images: |
-            ${{ env.REGISTRY_URL }}/${{ env.REGISTRY_USERNAME }}/${{ env.IMAGE_NAME }}
-          flavor: |
-            latest=false
-          tags: |
-            type=schedule,prefix=${{ matrix.distro }}-,pattern={{date 'YYYYMMDD'}}
-
       - name: Build Image
         id: build_image
         uses: redhat-actions/buildah-build@v2
         with:
-          context: ${{ matrix.distro }}
+          context: |
+            ./${{ env.DISTRO }}
           containerfiles: |
-            ./${{ matrix.distro }}/Containerfile
+            ./${{ env.DISTRO }}/Containerfile
           tags: |
-            ${{ steps.meta_distro.outputs.tags }}
-            ${{ steps.meta_latest.outputs.tags }}
+            ${{ steps.meta.outputs.tags }}
             ${{ steps.meta_pr.outputs.tags }}
             ${{ steps.meta_date.outputs.tags }}
+            ${{ steps.meta_version.outputs.tags }}
+            ${{ steps.meta_latest.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            MAJOR_VERSION=${{ matrix.major_version }}
           oci: false
 
       - name: Push to container registries
@@ -166,11 +143,11 @@ jobs:
             --disable-content-trust
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v2
+        uses: sigstore/cosign-installer@v3.1.2
 
       - name: Sign container image
         run: |
-          cosign sign --key env://COSIGN_PRIVATE_KEY ${{ env.REGISTRY_URL }}/${{ env.REGISTRY_USERNAME }}/${{ env.IMAGE_NAME }}@${TAGS}
+          cosign sign -y --key env://COSIGN_PRIVATE_KEY ${{ env.REGISTRY_URL }}/${{ env.REGISTRY_USERNAME }}/${{ env.IMAGE_NAME }}@${TAGS}
         env:
           TAGS: ${{ steps.push.outputs.digest }}
           COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_KEY }}

--- a/.github/workflows/fedora.yml
+++ b/.github/workflows/fedora.yml
@@ -1,0 +1,158 @@
+name: Build Fedora images
+
+on:
+  schedule:
+    - cron: '20 20 * * *'  # 8:20pm everyday
+  pull_request:
+    branches:
+      - main
+    paths:
+      - fedora/**
+      - .github/workflows/fedora.yml
+  push:
+    branches:
+      - main
+    paths:
+      - fedora/**
+      - .github/workflows/fedora.yml
+  workflow_dispatch:
+
+env:
+  DISTRO: 'fedora'
+  IMAGE_NAME: 'toolbx-fedora'
+  REGISTRY_URL: ghcr.io
+  REGISTRY_USERNAME: ${{ github.repository_owner }}
+  REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        major_version: [39, 40]
+        include:
+          - major_version: 39
+            is_latest: true
+          - major_version: 40
+            is_latest: false
+
+    steps:
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log into registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY_URL }}
+          username: ${{ env.REGISTRY_USERNAME }}
+          password: ${{ env.REGISTRY_PASSWORD }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.REGISTRY_URL }}/${{ env.REGISTRY_USERNAME }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            type=semver,pattern={{version}}
+            type=sha,prefix=sha256-
+
+      - name: Extract Docker PR tag
+        if: github.event_name == 'pull_request'
+        id: meta_pr
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.REGISTRY_URL }}/${{ env.REGISTRY_USERNAME }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            type=ref,suffix=-${{ matrix.major_version }},event=pr
+
+      - name: Extract Docker date tag
+        if: github.event_name == 'schedule'
+        id: meta_date
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.REGISTRY_URL }}/${{ env.REGISTRY_USERNAME }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            type=schedule,prefix=${{ matrix.major_version }}-,pattern={{date 'YYYYMMDD'}}
+
+      - name: Extract Docker major version tag
+        if: |
+          github.event_name != 'pull_request' && matrix.major_version != ''
+        id: meta_version
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.REGISTRY_URL }}/${{ env.REGISTRY_USERNAME }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            type=raw,value=${{ matrix.major_version }}
+
+      - name: Extract Docker latest tag
+        if: |
+          github.event_name != 'pull_request' && matrix.is_latest == true
+        id: meta_latest
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.REGISTRY_URL }}/${{ env.REGISTRY_USERNAME }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            type=raw,value=latest
+
+      - name: Build Image
+        id: build_image
+        uses: redhat-actions/buildah-build@v2
+        with:
+          context: |
+            ./${{ env.DISTRO }}
+          containerfiles: |
+            ./${{ env.DISTRO }}/Containerfile
+          tags: |
+            ${{ steps.meta.outputs.tags }}
+            ${{ steps.meta_pr.outputs.tags }}
+            ${{ steps.meta_date.outputs.tags }}
+            ${{ steps.meta_version.outputs.tags }}
+            ${{ steps.meta_latest.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            MAJOR_VERSION=${{ matrix.major_version }}
+          oci: false
+
+      - name: Push to container registries
+        uses: redhat-actions/push-to-registry@v2
+        id: push
+        with:
+          tags: ${{ steps.build_image.outputs.tags }}
+          extra-args: |
+            --disable-content-trust
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3.1.2
+
+      - name: Sign container image
+        run: |
+          cosign sign -y --key env://COSIGN_PRIVATE_KEY ${{ env.REGISTRY_URL }}/${{ env.REGISTRY_USERNAME }}/${{ env.IMAGE_NAME }}@${TAGS}
+        env:
+          TAGS: ${{ steps.push.outputs.digest }}
+          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_KEY }}
+          COSIGN_EXPERIMENTAL: false
+
+      - name: Echo outputs
+        run: |
+          echo "${{ toJSON(steps.push.outputs) }}"

--- a/.github/workflows/opensuse.yml
+++ b/.github/workflows/opensuse.yml
@@ -1,0 +1,158 @@
+name: Build openSUSE images
+
+on:
+  schedule:
+    - cron: '20 20 * * *'  # 8:20pm everyday
+  pull_request:
+    branches:
+      - main
+    paths:
+      - opensuse/**
+      - .github/workflows/opensuse.yml
+  push:
+    branches:
+      - main
+    paths:
+      - opensuse/**
+      - .github/workflows/opensuse.yml
+  workflow_dispatch:
+
+env:
+  DISTRO: 'opensuse'
+  IMAGE_NAME: 'toolbx-opensuse'
+  REGISTRY_URL: ghcr.io
+  REGISTRY_USERNAME: ${{ github.repository_owner }}
+  REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        major_version: ['latest', 'tumbleweed']
+        include:
+          - major_version: 'latest'
+            is_latest: true
+          - major_version: 'tumbleweed'
+            is_latest: false
+
+    steps:
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log into registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY_URL }}
+          username: ${{ env.REGISTRY_USERNAME }}
+          password: ${{ env.REGISTRY_PASSWORD }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.REGISTRY_URL }}/${{ env.REGISTRY_USERNAME }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            type=semver,pattern={{version}}
+            type=sha,prefix=sha256-
+
+      - name: Extract Docker PR tag
+        if: github.event_name == 'pull_request'
+        id: meta_pr
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.REGISTRY_URL }}/${{ env.REGISTRY_USERNAME }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            type=ref,suffix=-${{ matrix.major_version }},event=pr
+
+      - name: Extract Docker date tag
+        if: github.event_name == 'schedule'
+        id: meta_date
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.REGISTRY_URL }}/${{ env.REGISTRY_USERNAME }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            type=schedule,prefix=${{ matrix.major_version }}-,pattern={{date 'YYYYMMDD'}}
+
+      - name: Extract Docker major version tag
+        if: |
+          github.event_name != 'pull_request' && matrix.major_version != ''
+        id: meta_version
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.REGISTRY_URL }}/${{ env.REGISTRY_USERNAME }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            type=raw,value=${{ matrix.major_version }}
+
+      - name: Extract Docker latest tag
+        if: |
+          github.event_name != 'pull_request' && matrix.is_latest == true
+        id: meta_latest
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.REGISTRY_URL }}/${{ env.REGISTRY_USERNAME }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            type=raw,value=latest
+
+      - name: Build Image
+        id: build_image
+        uses: redhat-actions/buildah-build@v2
+        with:
+          context: |
+            ./${{ env.DISTRO }}
+          containerfiles: |
+            ./${{ env.DISTRO }}/Containerfile
+          tags: |
+            ${{ steps.meta.outputs.tags }}
+            ${{ steps.meta_pr.outputs.tags }}
+            ${{ steps.meta_date.outputs.tags }}
+            ${{ steps.meta_version.outputs.tags }}
+            ${{ steps.meta_latest.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            MAJOR_VERSION=${{ matrix.major_version }}
+          oci: false
+
+      - name: Push to container registries
+        uses: redhat-actions/push-to-registry@v2
+        id: push
+        with:
+          tags: ${{ steps.build_image.outputs.tags }}
+          extra-args: |
+            --disable-content-trust
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3.1.2
+
+      - name: Sign container image
+        run: |
+          cosign sign -y --key env://COSIGN_PRIVATE_KEY ${{ env.REGISTRY_URL }}/${{ env.REGISTRY_USERNAME }}/${{ env.IMAGE_NAME }}@${TAGS}
+        env:
+          TAGS: ${{ steps.push.outputs.digest }}
+          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_KEY }}
+          COSIGN_EXPERIMENTAL: false
+
+      - name: Echo outputs
+        run: |
+          echo "${{ toJSON(steps.push.outputs) }}"

--- a/.github/workflows/rhel.yml
+++ b/.github/workflows/rhel.yml
@@ -1,0 +1,156 @@
+name: Build RHEL images
+
+on:
+  schedule:
+    - cron: '20 20 * * *'  # 8:20pm everyday
+  pull_request:
+    branches:
+      - main
+    paths:
+      - rhel/**
+      - .github/workflows/rhel.yml
+  push:
+    branches:
+      - main
+    paths:
+      - rhel/**
+      - .github/workflows/rhel.yml
+  workflow_dispatch:
+
+env:
+  DISTRO: 'rhel'
+  IMAGE_NAME: 'toolbx-rhel'
+  REGISTRY_URL: ghcr.io
+  REGISTRY_USERNAME: ${{ github.repository_owner }}
+  REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        major_version: ['latest']
+        include:
+          - major_version: 'latest'
+            is_latest: true
+
+    steps:
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log into registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY_URL }}
+          username: ${{ env.REGISTRY_USERNAME }}
+          password: ${{ env.REGISTRY_PASSWORD }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.REGISTRY_URL }}/${{ env.REGISTRY_USERNAME }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            type=semver,pattern={{version}}
+            type=sha,prefix=sha256-
+
+      - name: Extract Docker PR tag
+        if: github.event_name == 'pull_request'
+        id: meta_pr
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.REGISTRY_URL }}/${{ env.REGISTRY_USERNAME }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            type=ref,suffix=-${{ matrix.major_version }},event=pr
+
+      - name: Extract Docker date tag
+        if: github.event_name == 'schedule'
+        id: meta_date
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.REGISTRY_URL }}/${{ env.REGISTRY_USERNAME }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            type=schedule,prefix=${{ matrix.major_version }}-,pattern={{date 'YYYYMMDD'}}
+
+      - name: Extract Docker major version tag
+        if: |
+          github.event_name != 'pull_request' && matrix.major_version != ''
+        id: meta_version
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.REGISTRY_URL }}/${{ env.REGISTRY_USERNAME }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            type=raw,value=${{ matrix.major_version }}
+
+      - name: Extract Docker latest tag
+        if: |
+          github.event_name != 'pull_request' && matrix.is_latest == true
+        id: meta_latest
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.REGISTRY_URL }}/${{ env.REGISTRY_USERNAME }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            type=raw,value=latest
+
+      - name: Build Image
+        id: build_image
+        uses: redhat-actions/buildah-build@v2
+        with:
+          context: |
+            ./${{ env.DISTRO }}
+          containerfiles: |
+            ./${{ env.DISTRO }}/Containerfile
+          tags: |
+            ${{ steps.meta.outputs.tags }}
+            ${{ steps.meta_pr.outputs.tags }}
+            ${{ steps.meta_date.outputs.tags }}
+            ${{ steps.meta_version.outputs.tags }}
+            ${{ steps.meta_latest.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            MAJOR_VERSION=${{ matrix.major_version }}
+          oci: false
+
+      - name: Push to container registries
+        uses: redhat-actions/push-to-registry@v2
+        id: push
+        with:
+          tags: ${{ steps.build_image.outputs.tags }}
+          extra-args: |
+            --disable-content-trust
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3.1.2
+
+      - name: Sign container image
+        run: |
+          cosign sign -y --key env://COSIGN_PRIVATE_KEY ${{ env.REGISTRY_URL }}/${{ env.REGISTRY_USERNAME }}/${{ env.IMAGE_NAME }}@${TAGS}
+        env:
+          TAGS: ${{ steps.push.outputs.digest }}
+          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_KEY }}
+          COSIGN_EXPERIMENTAL: false
+
+      - name: Echo outputs
+        run: |
+          echo "${{ toJSON(steps.push.outputs) }}"

--- a/.github/workflows/rockylinux.yml
+++ b/.github/workflows/rockylinux.yml
@@ -1,0 +1,156 @@
+name: Build Rocky Linux images
+
+on:
+  schedule:
+    - cron: '20 20 * * *'  # 8:20pm everyday
+  pull_request:
+    branches:
+      - main
+    paths:
+      - rockylinux/**
+      - .github/workflows/rockylinux.yml
+  push:
+    branches:
+      - main
+    paths:
+      - rockylinux/**
+      - .github/workflows/rockylinux.yml
+  workflow_dispatch:
+
+env:
+  DISTRO: 'rockylinux'
+  IMAGE_NAME: 'toolbx-rockylinux'
+  REGISTRY_URL: ghcr.io
+  REGISTRY_USERNAME: ${{ github.repository_owner }}
+  REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        major_version: [9]
+        include:
+          - major_version: 9
+            is_latest: true
+
+    steps:
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log into registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY_URL }}
+          username: ${{ env.REGISTRY_USERNAME }}
+          password: ${{ env.REGISTRY_PASSWORD }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.REGISTRY_URL }}/${{ env.REGISTRY_USERNAME }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            type=semver,pattern={{version}}
+            type=sha,prefix=sha256-
+
+      - name: Extract Docker PR tag
+        if: github.event_name == 'pull_request'
+        id: meta_pr
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.REGISTRY_URL }}/${{ env.REGISTRY_USERNAME }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            type=ref,suffix=-${{ matrix.major_version }},event=pr
+
+      - name: Extract Docker date tag
+        if: github.event_name == 'schedule'
+        id: meta_date
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.REGISTRY_URL }}/${{ env.REGISTRY_USERNAME }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            type=schedule,prefix=${{ matrix.major_version }}-,pattern={{date 'YYYYMMDD'}}
+
+      - name: Extract Docker major version tag
+        if: |
+          github.event_name != 'pull_request' && matrix.major_version != ''
+        id: meta_version
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.REGISTRY_URL }}/${{ env.REGISTRY_USERNAME }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            type=raw,value=${{ matrix.major_version }}
+
+      - name: Extract Docker latest tag
+        if: |
+          github.event_name != 'pull_request' && matrix.is_latest == true
+        id: meta_latest
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.REGISTRY_URL }}/${{ env.REGISTRY_USERNAME }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            type=raw,value=latest
+
+      - name: Build Image
+        id: build_image
+        uses: redhat-actions/buildah-build@v2
+        with:
+          context: |
+            ./${{ env.DISTRO }}
+          containerfiles: |
+            ./${{ env.DISTRO }}/Containerfile
+          tags: |
+            ${{ steps.meta.outputs.tags }}
+            ${{ steps.meta_pr.outputs.tags }}
+            ${{ steps.meta_date.outputs.tags }}
+            ${{ steps.meta_version.outputs.tags }}
+            ${{ steps.meta_latest.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            MAJOR_VERSION=${{ matrix.major_version }}
+          oci: false
+
+      - name: Push to container registries
+        uses: redhat-actions/push-to-registry@v2
+        id: push
+        with:
+          tags: ${{ steps.build_image.outputs.tags }}
+          extra-args: |
+            --disable-content-trust
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3.1.2
+
+      - name: Sign container image
+        run: |
+          cosign sign -y --key env://COSIGN_PRIVATE_KEY ${{ env.REGISTRY_URL }}/${{ env.REGISTRY_USERNAME }}/${{ env.IMAGE_NAME }}@${TAGS}
+        env:
+          TAGS: ${{ steps.push.outputs.digest }}
+          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_KEY }}
+          COSIGN_EXPERIMENTAL: false
+
+      - name: Echo outputs
+        run: |
+          echo "${{ toJSON(steps.push.outputs) }}"

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,0 +1,158 @@
+name: Build Ubuntu images
+
+on:
+  schedule:
+    - cron: '20 20 * * *'  # 8:20pm everyday
+  pull_request:
+    branches:
+      - main
+    paths:
+      - ubuntu/**
+      - .github/workflows/ubuntu.yml
+  push:
+    branches:
+      - main
+    paths:
+      - ubuntu/**
+      - .github/workflows/ubuntu.yml
+  workflow_dispatch:
+
+env:
+  DISTRO: 'ubuntu'
+  IMAGE_NAME: 'toolbx-ubuntu'
+  REGISTRY_URL: ghcr.io
+  REGISTRY_USERNAME: ${{ github.repository_owner }}
+  REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        major_version: ['20.04', '22.04']
+        include:
+          - major_version: '20.04'
+            is_latest: false
+          - major_version: '22.04'
+            is_latest: true
+
+    steps:
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log into registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY_URL }}
+          username: ${{ env.REGISTRY_USERNAME }}
+          password: ${{ env.REGISTRY_PASSWORD }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.REGISTRY_URL }}/${{ env.REGISTRY_USERNAME }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            type=semver,pattern={{version}}
+            type=sha,prefix=sha256-
+
+      - name: Extract Docker PR tag
+        if: github.event_name == 'pull_request'
+        id: meta_pr
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.REGISTRY_URL }}/${{ env.REGISTRY_USERNAME }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            type=ref,suffix=-${{ matrix.major_version }},event=pr
+
+      - name: Extract Docker date tag
+        if: github.event_name == 'schedule'
+        id: meta_date
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.REGISTRY_URL }}/${{ env.REGISTRY_USERNAME }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            type=schedule,prefix=${{ matrix.major_version }}-,pattern={{date 'YYYYMMDD'}}
+
+      - name: Extract Docker major version tag
+        if: |
+          github.event_name != 'pull_request' && matrix.major_version != ''
+        id: meta_version
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.REGISTRY_URL }}/${{ env.REGISTRY_USERNAME }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            type=raw,value=${{ matrix.major_version }}
+
+      - name: Extract Docker latest tag
+        if: |
+          github.event_name != 'pull_request' && matrix.is_latest == true
+        id: meta_latest
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.REGISTRY_URL }}/${{ env.REGISTRY_USERNAME }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            type=raw,value=latest
+
+      - name: Build Image
+        id: build_image
+        uses: redhat-actions/buildah-build@v2
+        with:
+          context: |
+            ./${{ env.DISTRO }}
+          containerfiles: |
+            ./${{ env.DISTRO }}/Containerfile
+          tags: |
+            ${{ steps.meta.outputs.tags }}
+            ${{ steps.meta_pr.outputs.tags }}
+            ${{ steps.meta_date.outputs.tags }}
+            ${{ steps.meta_version.outputs.tags }}
+            ${{ steps.meta_latest.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            MAJOR_VERSION=${{ matrix.major_version }}
+          oci: false
+
+      - name: Push to container registries
+        uses: redhat-actions/push-to-registry@v2
+        id: push
+        with:
+          tags: ${{ steps.build_image.outputs.tags }}
+          extra-args: |
+            --disable-content-trust
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3.1.2
+
+      - name: Sign container image
+        run: |
+          cosign sign -y --key env://COSIGN_PRIVATE_KEY ${{ env.REGISTRY_URL }}/${{ env.REGISTRY_USERNAME }}/${{ env.IMAGE_NAME }}@${TAGS}
+        env:
+          TAGS: ${{ steps.push.outputs.digest }}
+          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_KEY }}
+          COSIGN_EXPERIMENTAL: false
+
+      - name: Echo outputs
+        run: |
+          echo "${{ toJSON(steps.push.outputs) }}"

--- a/README.md
+++ b/README.md
@@ -1,51 +1,50 @@
 [toolbx-image][1]
 =================
 
-[![build-image](https://github.com/aguslr/toolbx-image/actions/workflows/build.yml/badge.svg)](https://github.com/aguslr/toolbx-image/actions/workflows/build.yml)
 
 Usage
 -----
 
 If you use [Toolbx][5]:
 
-    toolbox -i ghcr.io/aguslr/toolbx-image:latest -c toolbox
+    toolbox -i ghcr.io/aguslr/toolbx-fedora:latest -c toolbox
     toolbox enter toolbox
 
 If you use [Distrobox][6]:
 
-    distrobox create -i ghcr.io/aguslr/toolbx-image:latest -n distrobox
+    distrobox create -i ghcr.io/aguslr/toolbx-fedora:latest -n distrobox
     distrobox enter distrobox
 
 
 ### Tags
 
-There are several flavors for this container:
+There are several images available in this repository:
 
-- `fedora`, `latest`: Uses Fedora's latest image from
+- `toolbx-fedora`: Uses Fedora's latest image from
   <https://registry.fedoraproject.org/>.
 
-- `almalinux`: Uses Alma Linux's latest image from
+- `toolbx-almalinux`: Uses Alma Linux's latest image from
   <https://quay.io/organization/toolbx-images>.
 
-- `alpine`: Uses Alpine's latest image from
+- `toolbx-alpine`: Uses Alpine's latest image from
   <https://quay.io/organization/toolbx-images>.
 
-- `archlinux`: Uses Arch Linux's latest image from
+- `toolbx-archlinux`: Uses Arch Linux's latest image from
   <https://quay.io/organization/toolbx-images>.
 
-- `debian`: Uses Debian's latest image from
+- `toolbx-debian`: Uses Debian's latest image from
   <https://quay.io/organization/toolbx-images>.
 
-- `opensuse`: Uses openSUSE's latest image from
+- `toolbx-opensuse`: Uses openSUSE's latest image from
   <https://quay.io/organization/toolbx-images>.
 
-- `rhel`: Uses RHEL's latest image from
+- `toolbx-rhel`: Uses RHEL's latest image from
   <https://quay.io/organization/toolbx-images>.
 
-- `rockylinux`: Uses Rocky Linux's latest image from
+- `toolbx-rockylinux`: Uses Rocky Linux's latest image from
   <https://quay.io/organization/toolbx-images>.
 
-- `ubuntu`: Uses Ubuntu's latest image from
+- `toolbx-ubuntu`: Uses Ubuntu's latest image from
   <https://quay.io/organization/toolbx-images>.
 
 
@@ -56,7 +55,7 @@ These images are signed with Sisgstore's [Cosign][4]. You can verify the
 signature by downloading the `cosign.pub` key from this repo and running the
 following command:
 
-    cosign verify --key cosign.pub ghcr.io/aguslr/toolbx-image:latest
+    cosign verify --key cosign.pub ghcr.io/aguslr/toolbx-fedora:latest
 
 
 References

--- a/almalinux/Containerfile
+++ b/almalinux/Containerfile
@@ -1,4 +1,6 @@
-FROM quay.io/toolbx-images/almalinux-toolbox:latest
+ARG MAJOR_VERSION=9
+
+FROM quay.io/toolbx-images/almalinux-toolbox:${MAJOR_VERSION}
 
 LABEL com.github.containers.toolbox="true" \
       usage="This image is meant to be used with the toolbox or distrobox command" \

--- a/alpine/Containerfile
+++ b/alpine/Containerfile
@@ -1,4 +1,6 @@
-FROM quay.io/toolbx-images/alpine-toolbox:latest
+ARG MAJOR_VERSION=latest
+
+FROM quay.io/toolbx-images/alpine-toolbox:${MAJOR_VERSION}
 
 LABEL com.github.containers.toolbox="true" \
       usage="This image is meant to be used with the toolbox or distrobox command" \

--- a/archlinux/Containerfile
+++ b/archlinux/Containerfile
@@ -1,4 +1,6 @@
-FROM quay.io/toolbx-images/archlinux-toolbox:latest
+ARG MAJOR_VERSION=latest
+
+FROM quay.io/toolbx-images/archlinux-toolbox:${MAJOR_VERSION}
 
 LABEL com.github.containers.toolbox="true" \
       usage="This image is meant to be used with the toolbox or distrobox command" \

--- a/debian/Containerfile
+++ b/debian/Containerfile
@@ -1,4 +1,6 @@
-FROM quay.io/toolbx-images/debian-toolbox:latest
+ARG MAJOR_VERSION=12
+
+FROM quay.io/toolbx-images/debian-toolbox:${MAJOR_VERSION}
 
 LABEL com.github.containers.toolbox="true" \
       usage="This image is meant to be used with the toolbox or distrobox command" \

--- a/fedora/Containerfile
+++ b/fedora/Containerfile
@@ -1,4 +1,6 @@
-FROM registry.fedoraproject.org/fedora-toolbox:latest
+ARG MAJOR_VERSION=39
+
+FROM registry.fedoraproject.org/fedora-toolbox:${MAJOR_VERSION}
 
 LABEL com.github.containers.toolbox="true" \
       usage="This image is meant to be used with the toolbox or distrobox command" \

--- a/opensuse/Containerfile
+++ b/opensuse/Containerfile
@@ -1,4 +1,6 @@
-FROM quay.io/toolbx-images/opensuse-toolbox:latest
+ARG MAJOR_VERSION=latest
+
+FROM quay.io/toolbx-images/opensuse-toolbox:${MAJOR_VERSION}
 
 LABEL com.github.containers.toolbox="true" \
       usage="This image is meant to be used with the toolbox or distrobox command" \

--- a/rhel/Containerfile
+++ b/rhel/Containerfile
@@ -1,4 +1,6 @@
-FROM quay.io/toolbx-images/rhel-toolbox:latest
+ARG MAJOR_VERSION=latest
+
+FROM quay.io/toolbx-images/rhel-toolbox:${MAJOR_VERSION}
 
 LABEL com.github.containers.toolbox="true" \
       usage="This image is meant to be used with the toolbox or distrobox command" \

--- a/rockylinux/Containerfile
+++ b/rockylinux/Containerfile
@@ -1,4 +1,6 @@
-FROM quay.io/toolbx-images/rockylinux-toolbox:latest
+ARG MAJOR_VERSION=9
+
+FROM quay.io/toolbx-images/rockylinux-toolbox:${MAJOR_VERSION}
 
 LABEL com.github.containers.toolbox="true" \
       usage="This image is meant to be used with the toolbox or distrobox command" \

--- a/ubuntu/Containerfile
+++ b/ubuntu/Containerfile
@@ -1,4 +1,6 @@
-FROM quay.io/toolbx-images/ubuntu-toolbox:latest
+ARG MAJOR_VERSION=22.04
+
+FROM quay.io/toolbx-images/ubuntu-toolbox:${MAJOR_VERSION}
 
 LABEL com.github.containers.toolbox="true" \
       usage="This image is meant to be used with the toolbox or distrobox command" \


### PR DESCRIPTION
Use separate GitHub Actions files for each distribution so images can be build for different versions.